### PR TITLE
feat: add placeholder, placeholderStyle to FormBuilderCupertinoTextField

### DIFF
--- a/lib/src/fields/form_builder_cupertino_text_field.dart
+++ b/lib/src/fields/form_builder_cupertino_text_field.dart
@@ -63,6 +63,26 @@ class FormBuilderCupertinoTextField extends FormBuilderField<String> {
   /// {@macro flutter.services.textInput.enableSuggestions}
   final bool enableSuggestions;
 
+  /// A lighter colored placeholder hint that appears on the first line of the
+  /// text field when the text entry is empty.
+  ///
+  /// Defaults to having no placeholder text.
+  ///
+  /// The text style of the placeholder text matches that of the text field's
+  /// main text entry except a lighter font weight and a grey font color.
+  final String? placeholder;
+
+  /// The style to use for the placeholder text.
+  ///
+  /// The [placeholderStyle] is merged with the [style] [TextStyle] when applied
+  /// to the [placeholder] text. To avoid merging with [style], specify
+  /// [TextStyle.inherit] as false.
+  ///
+  /// Defaults to the [style] property with w300 font weight and grey color.
+  ///
+  /// If specifically set to null, placeholder's style will be the same as [style].
+  final TextStyle? placeholderStyle;
+
   /// {@macro flutter.widgets.editableText.maxLines}
   final int? maxLines;
 
@@ -342,6 +362,8 @@ class FormBuilderCupertinoTextField extends FormBuilderField<String> {
     this.scribbleEnabled = true,
     this.clearButtonMode = OverlayVisibilityMode.never,
     this.contentInsertionConfiguration,
+    this.placeholder,
+    this.placeholderStyle
   })  : assert(maxLines == null || maxLines > 0),
         assert(minLines == null || minLines > 0),
         assert(
@@ -386,6 +408,8 @@ class FormBuilderCupertinoTextField extends FormBuilderField<String> {
               obscureText: obscureText,
               autocorrect: autocorrect,
               enableSuggestions: enableSuggestions,
+              placeholder: placeholder,
+              placeholderStyle: placeholderStyle,
               maxLengthEnforcement: maxLengthEnforcement,
               maxLines: maxLines,
               minLines: minLines,


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #7 

## Solution description
Added optional placeholder and placeholderStyle to FormBuilderCupertinoTextField, so now users can add placeholder if they'd like
## Screenshots or Videos

![Screenshot 2023-10-06 at 4 34 42 PM](https://github.com/flutter-form-builder-ecosystem/form_builder_cupertino_fields/assets/10715648/d65a7ad4-4563-40be-970d-f9134cf6f0a1)


## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] ~Add unit test to verify new or fixed behaviour~  *Difficult to test placeholder text*
- [x] If apply, add documentation to code properties and package readme
