### PR TITLE
feat: add onTapOutside to FormBuilderCupertinoTextField

### DIFF
--- a/lib/src/fields/form_builder_cupertino_text_field.dart
+++ b/lib/src/fields/form_builder_cupertino_text_field.dart
@@ -146,6 +146,9 @@ class FormBuilderCupertinoTextField extends FormBuilderField<String> {
   ///    [TextInputAction.previous] for [textInputAction].
   final ValueChanged<String?>? onSubmitted;
 
+  /// {@macro flutter.widgets.editableText.onTapOutside}
+  final TapRegionCallback? onTapOutside;
+
   /// {@macro flutter.widgets.editableText.inputFormatters}
   final List<TextInputFormatter>? inputFormatters;
 
@@ -339,6 +342,7 @@ class FormBuilderCupertinoTextField extends FormBuilderField<String> {
     this.minLines,
     this.showCursor,
     this.onTap,
+    this.onTapOutside,
     this.enableSuggestions = false,
     this.textAlignVertical,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -416,6 +420,7 @@ class FormBuilderCupertinoTextField extends FormBuilderField<String> {
               expands: expands,
               maxLength: maxLength,
               onTap: onTap,
+              onTapOutside: onTapOutside,
               onEditingComplete: onEditingComplete,
               onSubmitted: onSubmitted,
               inputFormatters: inputFormatters,


### PR DESCRIPTION
## Solution description

Add support of missing TextField's property `onTapOutside` (https://api.flutter.dev/flutter/material/TextField/onTapOutside.html)

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
